### PR TITLE
Make Python default language

### DIFF
--- a/src/judge0/submission.py
+++ b/src/judge0/submission.py
@@ -54,8 +54,8 @@ class Submission:
     def __init__(
         self,
         source_code: str,
-        language_id: Union[Language, int],
         *,
+        language_id: Union[Language, int]=Language.PYTHON,
         additional_files=None,
         compiler_options=None,
         command_line_arguments=None,


### PR DESCRIPTION
I want this example to work:
```python
import judge0
submission = judge0.Submission(source_code="print('Hello Judge0')")
judge0.run(submissions=submission)
print(submission.stdout)
```