### PR TITLE
Add support for env variable JUDGE0_SUPPRESS_PREVIEW_WARNING.

### DIFF
--- a/src/judge0/__init__.py
+++ b/src/judge0/__init__.py
@@ -65,6 +65,7 @@ __all__ = [
 
 JUDGE0_IMPLICIT_CE_CLIENT = None
 JUDGE0_IMPLICIT_EXTRA_CE_CLIENT = None
+SUPPRESS_PREVIEW_WARNING = os.getenv("JUDGE0_SUPPRESS_PREVIEW_WARNING")
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +107,7 @@ def _get_implicit_client(flavor: Flavor) -> Client:
 
 
 def _get_preview_client(flavor: Flavor) -> Union[Judge0CloudCE, Judge0CloudExtraCE]:
-    if not suppress_preview_warning:
+    if SUPPRESS_PREVIEW_WARNING is not None:
         logger.warning(
             "You are using a preview version of the client which is not recommended"
             " for production.\n"
@@ -235,5 +236,3 @@ SQLITE = LanguageAlias.SQLITE
 SWIFT = LanguageAlias.SWIFT
 TYPESCRIPT = LanguageAlias.TYPESCRIPT
 VISUAL_BASIC = LanguageAlias.VISUAL_BASIC
-
-suppress_preview_warning = os.getenv("JUDGE0_SUPPRESS_PREVIEW_WARNING") is not None


### PR DESCRIPTION
Hi @fkdosilovic,

The intention for this PR is to be able to deliberately disable (suppress) preview warning by either setting env variable `JUDGE0_SUPPRESS_PREVIEW_WARNING` to any value or by explicitly setting `judge0.suppress_preview_warning = True`.

Here are examples that work with these changes:

### Example 1
```python
# File example.py
import judge0
result = judge0.run(source_code="print('hello, world')", language=judge0.PYTHON)
print(result.stdout)
```

Any of these would cause the preview warning to be suppressed:
```bash
JUDGE0_SUPPRESS_PREVIEW_WARNING=True python3 example.py
JUDGE0_SUPPRESS_PREVIEW_WARNING=1 python3 example.py
JUDGE0_SUPPRESS_PREVIEW_WARNING=asdf python3 example.py
JUDGE0_SUPPRESS_PREVIEW_WARNING= python3 example.py
```

### Example 2
```python
import judge0
judge0.suppress_preview_warning = True
result = judge0.run(source_code="print('hello, world')", language=judge0.PYTHON)
print(result.stdout)
```

I don't know if this is idiomatic way of doing this in Python. If it's not, please adjust the PR accordingly such that the above can be achieved.

Thank you!