### PR TITLE
Don't require auth_headers in judge0.Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ This example shows how to use Judge0 Python SDK with your own Judge0 instance.
 ```python
 import judge0
 
-client = judge0.Client("http://127.0.0.1:2358", None)
+client = judge0.Client("http://127.0.0.1:2358")
 
 source_code = """
 #include <stdio.h>

--- a/src/judge0/clients.py
+++ b/src/judge0/clients.py
@@ -33,7 +33,7 @@ class Client:
     def __init__(
         self,
         endpoint,
-        auth_headers,
+        auth_headers=None,
         *,
         retry_strategy: Optional[RetryStrategy] = None,
     ) -> None:


### PR DESCRIPTION
Hi @fkdosilovic,

I think we can drop `auth_headers` as required argument when creating an instance of `judge0.Client`.