### PR TITLE
docs: add general API overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.1.0-dev
 
+- Document the general API overview: high-level versus low-level functions,
+  core types, and the typical `run` / `async_run` flow.
 - Fix Sphinx autodoc imports for Pydantic-backed submission types.
 - Add complete static typing across the SDK and tests, with typed single and batch
   submission return values.

--- a/docs/source/in_depth/overview.rst
+++ b/docs/source/in_depth/overview.rst
@@ -1,8 +1,150 @@
 Overview
 ========
 
-TODO:
+The Judge0 Python SDK has two layers:
 
-* add a brief overview of the most important classes (Client, Submission, etc.)
-* add a brief overview of the most important functions (create_submission, get_submission, etc.)
-* write about the difference between high-level api and low-level api
+* a **high-level API** that creates submissions, expands test cases, batches
+  requests, and optionally waits for results;
+* a **low-level API** on :class:`~judge0.clients.Client` that maps one-to-one
+  to Judge0 HTTP routes.
+
+Most applications should start with :func:`judge0.run`. Use the client methods
+when you need a single HTTP call, custom polling, or server metadata.
+
+High-level and low-level API
+----------------------------
+
+High-level functions live in :mod:`judge0.api` and are re-exported from the
+``judge0`` package. They accept either source code, a
+:class:`~judge0.submission.Submission`, or a sequence of submissions. If you
+omit ``client``, the SDK resolves one from the environment. See
+:doc:`client_resolution`.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 72
+
+   * - Function
+     - Role
+   * - :func:`judge0.run` / :func:`judge0.execute` / :func:`judge0.sync_run`
+     - Create submission(s) and wait until they finish. These names are aliases
+       of :func:`judge0.api.sync_execute`.
+   * - :func:`judge0.async_run` / :func:`judge0.async_execute`
+     - Create submission(s) and return immediately. These are **not**
+       ``asyncio`` coroutines.
+   * - :func:`judge0.wait`
+     - Poll existing submission(s) until they finish or the retry strategy
+       stops.
+   * - :func:`judge0.get_client`
+     - Resolve the implicit client for CE (``Flavor.CE``) or Extra CE
+       (``Flavor.EXTRA_CE``).
+   * - :func:`judge0.api.create_submissions`
+     - Send already-built submissions, splitting them into batches that fit
+       the server limit.
+   * - :func:`judge0.api.get_submissions`
+     - Refresh status and result fields on existing submissions.
+   * - :func:`judge0.api.create_submissions_from_test_cases`
+     - Expand one or more submissions across test cases. Used internally by
+       :func:`judge0.run`.
+
+The low-level API is the methods on :class:`~judge0.clients.Client`:
+
+* :meth:`~judge0.clients.Client.create_submission` /
+  :meth:`~judge0.clients.Client.create_submissions`
+* :meth:`~judge0.clients.Client.get_submission` /
+  :meth:`~judge0.clients.Client.get_submissions`
+* :meth:`~judge0.clients.Client.get_languages`,
+  :meth:`~judge0.clients.Client.get_language`,
+  :meth:`~judge0.clients.Client.get_statuses`,
+  :meth:`~judge0.clients.Client.get_about`,
+  :meth:`~judge0.clients.Client.get_config_info`
+
+Low-level calls do not wait for execution, do not expand test cases, and do
+not pick a client for you. ``create_submissions`` and ``get_submissions`` on
+the client cannot send more items than
+``client.config.max_submission_batch_size``. The high-level helpers batch
+automatically.
+
+``async_run`` versus ``run``
+----------------------------
+
+:func:`judge0.run` blocks until Judge0 reports a terminal status.
+:func:`judge0.async_run` only creates the submission(s) and returns tokens.
+Call :func:`judge0.wait` later, or poll with
+:func:`judge0.api.get_submissions`.
+
+.. code-block:: python
+
+    import judge0
+
+    submission = judge0.async_run(source_code="print('hello, world')")
+    print(submission.stdout)  # None; the job is not finished yet.
+
+    judge0.wait(submissions=submission)
+    print(submission.stdout)  # hello, world
+
+Important classes
+-----------------
+
+* :class:`~judge0.clients.Client`: HTTP client for one Judge0 server.
+  Provider subclasses include :class:`~judge0.clients.Judge0CloudCE`,
+  :class:`~judge0.clients.RapidJudge0CE`, and
+  :class:`~judge0.clients.ATDJudge0CE`, plus the Extra CE variants.
+* :class:`~judge0.submission.Submission`: request and response for one
+  program run. Set ``source_code``, ``language``, ``stdin``, and optional
+  limits before sending. After execution, read ``stdout``, ``stderr``,
+  ``status``, ``time``, and ``memory``.
+* :class:`~judge0.base_types.TestCase`: pair of ``input`` and
+  ``expected_output``. :func:`judge0.run` also accepts tuples, lists, and
+  dicts and normalizes them to this type.
+* :class:`~judge0.base_types.LanguageAlias` and
+  :class:`~judge0.base_types.Flavor`: language aliases such as
+  ``judge0.PYTHON`` or ``judge0.C``, and the CE / Extra CE flavors used
+  for client resolution.
+* :class:`~judge0.base_types.Status`: submission status, including
+  ``Accepted``, compile errors, and runtime errors.
+* :class:`~judge0.filesystem.File` and
+  :class:`~judge0.filesystem.Filesystem`: extra files sent with a
+  submission, or files produced after execution.
+* :class:`~judge0.retry.RegularPeriodRetry`,
+  :class:`~judge0.retry.MaxRetries`, and
+  :class:`~judge0.retry.MaxWaitTime`: polling strategies used by
+  :func:`judge0.wait`.
+
+Typical flow
+------------
+
+1. Build source code or a :class:`~judge0.submission.Submission`.
+2. Optionally attach test cases or extra files.
+3. Call :func:`judge0.run`, or :func:`judge0.async_run` plus
+   :func:`judge0.wait`.
+4. Inspect ``stdout``, ``status``, and other result fields.
+
+.. code-block:: python
+
+    import judge0
+
+    result = judge0.run(
+        source_code="print(f'Hello, {input()}!')",
+        language=judge0.PYTHON,
+        test_cases=[
+            ("Ada", "Hello, Ada!"),
+            {"input": "Bob", "expected_output": "Hello, Bob!"},
+        ],
+    )
+
+    for case in result:
+        print(case.status, case.stdout)
+
+Pass an explicit client when you do not want implicit resolution:
+
+.. code-block:: python
+
+    import judge0
+
+    client = judge0.RapidJudge0CE(api_key="xxx")
+    result = judge0.run(client=client, source_code="print(42)")
+    print(result.stdout)
+
+For the full parameter lists, see the :doc:`/api/api` reference, the
+:doc:`/api/clients` reference, and the :doc:`/api/submission` reference.


### PR DESCRIPTION
## Summary

- Replace the TODO placeholder in `docs/source/in_depth/overview.rst` with a General API Overview.
- Cover high-level vs low-level APIs, core types, and the typical `run` / `async_run` flow.

## Motivation

Closes #29

The In Depth overview page was added as a stub (`Add placeholder for API overview.`) and never written. The placeholder asked for:

- important classes (`Client`, `Submission`, …)
- important functions (`create_submission`, `get_submission`, `run`, …)
- the difference between the high-level and low-level APIs

## Changes

- High-level helpers: `run` / `execute` / `async_run` / `wait` / `get_client`, plus the `judge0.api` batch helpers.
- Low-level `Client` methods that map to Judge0 HTTP routes.
- Explicit note that `async_run` is not an `asyncio` coroutine.
- Short examples for wait-later execution, test cases, and an explicit client.

## Test Plan

- [x] `uv run sphinx-build -b html docs/source ... -W` succeeds
- [x] Overview HTML contains the four sections and has no leftover TODO
- [ ] Docs deploy runs only on `master` (not on PRs)

## Notes for Reviewers

`create_submissions` / `get_submissions` are documented as `judge0.api.*` because they are not re-exported from `judge0.__all__`.