### PR TITLE
docs: show last 10 versions in the docs sidebar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@
   - `version.py` exposes the package version constant.
 - `tests/` contains the pytest suite. Shared fixtures belong in `conftest.py`, and focused tests should use `test_<area>.py` modules that correspond to SDK behavior.
 - `examples/` contains runnable SDK usage examples, including the standalone HTTP callback example in `examples/1000_http_callback_aka_webhook/`.
-- `docs/source/` contains the Sphinx documentation sources. API reference pages live in `docs/source/api/`, contributor documentation in `docs/source/contributors_guide/`, and conceptual guides in `docs/source/in_depth/`. Sphinx configuration and templates also live under `docs/source/`; `docs/assets/` contains documentation assets.
+- `docs/source/` contains the Sphinx documentation sources. API reference pages live in `docs/source/api/`, contributor documentation in `docs/source/contributors_guide/`, conceptual guides in `docs/source/in_depth/`, and the FAQ in `docs/source/faq.rst`. Sphinx configuration and templates also live under `docs/source/`; `docs/assets/` contains documentation assets.
 - `.github/` contains CI workflows and GitHub issue templates.
 - `pyproject.toml` defines package metadata, dependencies, dependency groups, and tool configuration; `uv.lock` pins the resolved environment. Manage both through `uv` as described above.
 - Root-level Markdown files contain the project overview, contribution and conduct policies, release-note template, changelog, and agent instructions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Bump the uv version used in GitHub Actions from 0.9.8 to 0.11.33 so that the
   CI can parse the relative `exclude-newer` value in `pyproject.toml`.
+- Show only the last 10 documentation versions in the sidebar, collapse older
+  tags under "View more...", and document how to open older docs in the FAQ.
 - Fix Sphinx autodoc imports for Pydantic-backed submission types.
 - Add complete static typing across the SDK and tests, with typed single and batch
   submission return values.

--- a/docs/source/_templates/versioning.html
+++ b/docs/source/_templates/versioning.html
@@ -1,11 +1,21 @@
 {% if versions %}
-{% set master_version = versions | selectattr('name', 'equalto', 'master') | list %}
-{% set other_versions = versions | rejectattr('name', 'equalto', 'master') | sort(attribute='name', reverse=true) %}
-{% set sorted_versions = master_version + other_versions %}
+{% set version_groups = versions | split_doc_versions %}
+{% set visible_versions = version_groups[0] %}
+{% set older_versions = version_groups[1] %}
 <h3>{{ _('Versions') }}</h3>
 <ul>
-    {%- for item in sorted_versions %}
+    {%- for item in visible_versions %}
     <li><a href="{{ item.url }}">{{ item.name }}</a></li>
     {%- endfor %}
 </ul>
+{% if older_versions %}
+<details class="versions-more">
+    <summary>{{ _('View more...') }}</summary>
+    <ul>
+        {%- for item in older_versions %}
+        <li><a href="{{ item.url }}">{{ item.name }}</a></li>
+        {%- endfor %}
+    </ul>
+</details>
+{% endif %}
 {% endif %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,6 +9,7 @@
 
 import os
 import sys
+from typing import Any
 
 from sphinxawesome_theme.postprocess import Icons
 
@@ -89,6 +90,9 @@ html_favicon = "../assets/logo.png"
 pygments_style = "sphinx"
 
 sys.path.insert(0, os.path.abspath("../../src/"))  # Adjust as needed
+sys.path.insert(0, os.path.abspath("."))
+
+from version_sidebar import split_doc_versions  # noqa: E402
 
 # -- Awesome theme config --
 html_permalinks_icon = Icons.permalinks_icon
@@ -118,3 +122,19 @@ smv_outputdir_format = "{ref.name}"
 # Determines whether remote or local git branches/tags are preferred if their
 # output dirs conflict
 smv_prefer_remote_refs = False
+
+
+def _register_version_sidebar_filter(app: Any) -> None:
+    """Add the version split helper to the HTML Jinja environment."""
+    app.builder.templates.environment.filters["split_doc_versions"] = (
+        split_doc_versions
+    )
+
+
+def setup(app: Any) -> dict[str, bool]:
+    """Register the version sidebar template filter."""
+    app.connect("builder-inited", _register_version_sidebar_filter)
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -1,0 +1,19 @@
+FAQ
+===
+
+How do I view documentation for an older version?
+-------------------------------------------------
+
+The documentation site keeps a copy of each published release. The
+**Versions** list in the left sidebar shows ``master`` and the nine most
+recent release tags. Older tags are collapsed under **View more...**.
+
+Direct links to older versions keep working even when a tag is not in
+the first ten sidebar entries. Open:
+
+``https://python.docs.judge0.com/<tag>/``
+
+Replace ``<tag>`` with the Git tag, for example
+`v0.0.1 <https://python.docs.judge0.com/v0.0.1/>`_. The current
+development docs are always at
+`https://python.docs.judge0.com/master/ <https://python.docs.judge0.com/master/>`_.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -83,3 +83,11 @@ Every contribution, big or small, is valuable!
 
       contributors_guide/contributing
       contributors_guide/release_notes
+
+
+.. toctree::
+      :caption: FAQ
+      :titlesonly:
+      :hidden:
+
+      faq

--- a/docs/source/version_sidebar.py
+++ b/docs/source/version_sidebar.py
@@ -1,0 +1,41 @@
+"""Helpers for the Sphinx documentation version sidebar."""
+
+from collections.abc import Iterable
+from typing import TypeVar
+
+T = TypeVar("T")
+
+VISIBLE_DOC_VERSION_LIMIT = 10
+
+
+def split_doc_versions(
+    versions: Iterable[T],
+    *,
+    limit: int = VISIBLE_DOC_VERSION_LIMIT,
+) -> tuple[list[T], list[T]]:
+    """Split versions into the sidebar list and older collapsed entries.
+
+    ``master`` is shown first. Remaining names are sorted in reverse
+    lexicographic order, matching the previous sidebar template.
+
+    Parameters
+    ----------
+    versions : iterable
+        Version objects with a ``name`` attribute.
+    limit : int, optional
+        Number of versions to keep visible. Defaults to 10.
+
+    Returns
+    -------
+    tuple of list
+        Visible versions and older versions hidden under "View more...".
+    """
+    items = list(versions)
+    master = [item for item in items if getattr(item, "name", None) == "master"]
+    others = sorted(
+        (item for item in items if getattr(item, "name", None) != "master"),
+        key=lambda item: str(getattr(item, "name", "")),
+        reverse=True,
+    )
+    ordered = master + others
+    return ordered[:limit], ordered[limit:]

--- a/tests/test_version_sidebar.py
+++ b/tests/test_version_sidebar.py
@@ -1,0 +1,74 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "docs" / "source" / "version_sidebar.py"
+)
+
+
+def _load_version_sidebar() -> Any:
+    spec = spec_from_file_location("version_sidebar", _MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {_MODULE_PATH}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _version(name: str) -> SimpleNamespace:
+    return SimpleNamespace(name=name, url=f"/{name}/")
+
+
+def test_visible_limit_is_ten() -> None:
+    version_sidebar = _load_version_sidebar()
+    assert version_sidebar.VISIBLE_DOC_VERSION_LIMIT == 10
+
+
+def test_master_is_first_and_only_ten_are_visible() -> None:
+    version_sidebar = _load_version_sidebar()
+    versions = [_version(f"v0.0.{i}") for i in range(1, 13)]
+    versions.append(_version("master"))
+
+    visible, older = version_sidebar.split_doc_versions(versions)
+
+    assert [item.name for item in visible] == [
+        "master",
+        "v0.0.9",
+        "v0.0.8",
+        "v0.0.7",
+        "v0.0.6",
+        "v0.0.5",
+        "v0.0.4",
+        "v0.0.3",
+        "v0.0.2",
+        "v0.0.12",
+    ]
+    assert [item.name for item in older] == ["v0.0.11", "v0.0.10", "v0.0.1"]
+
+
+def test_fewer_than_limit_has_no_older_versions() -> None:
+    version_sidebar = _load_version_sidebar()
+    versions = [_version("master"), _version("v0.0.2"), _version("v0.0.1")]
+
+    visible, older = version_sidebar.split_doc_versions(versions)
+
+    assert [item.name for item in visible] == ["master", "v0.0.2", "v0.0.1"]
+    assert older == []
+
+
+def test_empty_versions() -> None:
+    version_sidebar = _load_version_sidebar()
+    visible, older = version_sidebar.split_doc_versions([])
+
+    assert visible == []
+    assert older == []
+
+
+def test_sidebar_template_collapses_older_versions() -> None:
+    text = (_MODULE_PATH.parent / "_templates" / "versioning.html").read_text()
+
+    assert "split_doc_versions" in text
+    assert "View more..." in text
+    assert "older_versions" in text


### PR DESCRIPTION
## Summary

- Show only the last 10 documentation versions in the left sidebar (`master` first, then newest tags).
- Collapse older tags under **View more...** so they stay reachable from the UI.
- Add a FAQ page that explains how to open older version URLs directly.

Same work as #47, opened from `judge0/judge0-python` so Actions can receive repository secrets. Rebased onto current `master` (CHANGELOG only).

## Motivation

Closes #40

The Versions list will grow with every release. The issue asks to keep the sidebar to the last 10 versions, keep older docs reachable, and document how to visit them.

## Changes

- `docs/source/version_sidebar.py` splits the version list.
- `docs/source/_templates/versioning.html` renders the first 10 entries and a **View more...** disclosure for the rest.
- `docs/source/faq.rst` documents `https://python.docs.judge0.com/<tag>/`.
- `docs/source/conf.py` registers the Jinja filter on `builder-inited`.
- Unit tests cover the 10-item split and the sidebar template contract.

Older version URLs keep working because sphinx-multiversion still builds every matching tag. This only changes what the sidebar lists.

## Test Plan

- [x] `uv run pytest tests/test_version_sidebar.py` (5 passed)
- [x] `uv run ruff check` / `ruff format --check` / `pyright`
- [x] `uv run sphinx-build -b html docs/source ... -W` succeeds and publishes `faq.html`
- [ ] Live `sphinx-multiversion` deploy on `master` (docs workflow does not run on PRs)

## Notes for Reviewers

There are currently fewer than 10 published `vX.Y.Z` tags plus `master`, so **View more...** will not appear until the 11th version exists. The unit tests cover that case with a synthetic 13-version list.

Name sort is unchanged (reverse lexicographic), matching the previous template.

Fork PR: #47
